### PR TITLE
Add corrupted option

### DIFF
--- a/docs/columns/options.md
+++ b/docs/columns/options.md
@@ -13,3 +13,18 @@ Default value is **1**, or always present.
 The parameter should be set between 0 and 1, otherwise it will be set to the closest.
 
 In this example, 80% of the column will be generated, 20% will be missing.
+
+### Corrupted
+```yaml
+ - name: column_name
+   provider: Any.provider
+   corrupted: 0.001
+```
+Adds a percentage of corruption to the column: the provider asked will not validate the asked rule.
+For example for an email, the resulting will not be an email.
+For a random date or integer, it will not use the interval you provide.
+
+Default value is **0**, or no corruption.
+The parameter should be set between 0 and 1, otherwise it will be set to the closest.
+
+In this example, 0.1% of the column will be corrupted.

--- a/docs/columns/providers/increment.md
+++ b/docs/columns/providers/increment.md
@@ -13,3 +13,5 @@ It starts from the optional parameter **start**. Default is 0.
 It increments by the optional parameter **step**. Default is 1.
  
 [Options](../options.md) are also possible.
+
+In this case, corrupted means random int32.

--- a/docs/columns/providers/person.md
+++ b/docs/columns/providers/person.md
@@ -14,6 +14,8 @@ Create a random email with:
 
 [Options](../options.md) are also possible.
 
+In this case, corrupted means random string not in UTF8 format.
+
 ### fname
 ```yaml
  - name: first_name_in_top_1000_fr
@@ -23,6 +25,8 @@ Returns a random first name from top 1000 french list.
 
 [Options](../options.md) are also possible.
 
+In this case, corrupted means random string not in UTF8 format.
+
 ### lname
 ```yaml
  - name: last_name_in_top_1000_fr
@@ -31,3 +35,5 @@ Returns a random first name from top 1000 french list.
 Returns a random last name from top 1000 french list.
 
 [Options](../options.md) are also possible.
+
+In this case, corrupted means random string not in UTF8 format.

--- a/docs/columns/providers/random.md
+++ b/docs/columns/providers/random.md
@@ -10,6 +10,8 @@ Create a random boolean.
 
 [Options](../options.md) are also possible.
 
+In this case, corrupted does not change anything as it is still a boolean.
+
 ### Date
 ##### date
 ```yaml
@@ -27,6 +29,8 @@ Create a random date with:
 
 [Options](../options.md) are also possible.
 
+In this case, corrupted means random date without using the parameters as limit.
+
 ##### datetime
 ```yaml
  - name: connection
@@ -42,6 +46,8 @@ Create a random datetime with:
 - an optional parameter **before** as a upper boundary. It should follow the **format** parameter. Default is 2000-01-01 12:00:00
 
 [Options](../options.md) are also possible.
+
+In this case, corrupted means random datetime without using the parameters as limit.
 
 ### Number
 ##### f64
@@ -72,6 +78,8 @@ Create a random 32 bits integer with:
 
 [Options](../options.md) are also possible.
 
+In this case, corrupted means random int32 without using the parameters as limit.
+
 ### String
 ##### alphanumeric
 ```yaml
@@ -84,3 +92,5 @@ Create a random string, with only Alphanumerics characters.
 - an optional parameter **length** to specify the length of the string. This parameter can be a range `5..15` or a constant `8`. Default is 10.
 
 [Options](../options.md) are also possible.
+
+In this case, corrupted means random string not in UTF8 format.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ columns:
   - name: company_email
     provider: Person.email
     domain: soma-smart.com
+    corrupted: 0.0001
 
   - name: created
     provider: Random.Date.date

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use yaml_rust::{Yaml, YamlLoader};
 
 use crate::errors::FakeLakeError;
 use crate::options::presence;
-use crate::providers::provider::{Provider, ProviderBuilder};
+use crate::providers::provider::{CorruptedProvider, Provider, ProviderBuilder};
 
 #[derive(Debug)]
 pub struct Config {
@@ -106,7 +106,7 @@ impl Column {
 
             let provider: Box<dyn Provider> =
                 match ProviderBuilder::get_corresponding_provider(provider, column) {
-                    Ok(value) => value,
+                    Ok(value) => CorruptedProvider::new_from_yaml(column, value),
                     Err(e) => return Err(FakeLakeError::BadYAMLFormat(e.to_string())),
                 };
 
@@ -226,7 +226,6 @@ mod tests {
 
     use mockall::predicate::*;
     use mockall::*;
-    use yaml_rust::Yaml;
 
     #[derive(Clone)]
     struct TestProvider;
@@ -239,7 +238,7 @@ mod tests {
 
         impl Provider for TestProvider {
             fn value(&self, index: u32) -> Value;
-            fn new_from_yaml(column: &Yaml) -> Self where Self: Sized;
+            fn corrupted_value(&self, index: u32) -> Value;
         }
     }
 

--- a/src/providers/increment/builder.rs
+++ b/src/providers/increment/builder.rs
@@ -1,7 +1,7 @@
 use crate::errors::FakeLakeError;
 use crate::providers::provider::Provider;
 
-use super::integer::IncrementIntegerProvider;
+use super::integer;
 
 use yaml_rust::Yaml;
 
@@ -10,7 +10,7 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("integer") => Ok(Box::new(IncrementIntegerProvider::new_from_yaml(column))),
+        Some("integer") => Ok(integer::new_from_yaml(column)),
         _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
     }
 }

--- a/src/providers/increment/integer.rs
+++ b/src/providers/increment/integer.rs
@@ -1,6 +1,7 @@
 use crate::providers::parameters::i32::I32Parameter;
 use crate::providers::provider::{Provider, Value};
 
+use fastrand;
 use yaml_rust::Yaml;
 
 const DEFAULT_START: i32 = 0;
@@ -16,25 +17,32 @@ impl Provider for IncrementIntegerProvider {
     fn value(&self, index: u32) -> Value {
         Value::Int32(self.start + ((index as i32) * self.step))
     }
-    fn new_from_yaml(column: &Yaml) -> IncrementIntegerProvider {
-        let start_param = I32Parameter::new(column, "start", DEFAULT_START);
-        let step_param = I32Parameter::new(column, "step", DEFAULT_STEP);
-
-        IncrementIntegerProvider {
-            start: start_param.value,
-            step: step_param.value,
-        }
+    fn corrupted_value(&self, _: u32) -> Value {
+        // return random i32
+        Value::Int32(fastrand::i32(i32::MIN..i32::MAX))
     }
+}
+
+pub fn new_from_yaml(column: &Yaml) -> Box<IncrementIntegerProvider> {
+    let start_param = I32Parameter::new(column, "start", DEFAULT_START);
+    let step_param = I32Parameter::new(column, "step", DEFAULT_STEP);
+
+    Box::new(IncrementIntegerProvider {
+        start: start_param.value,
+        step: step_param.value,
+    })
 }
 
 #[cfg(test)]
 mod tests {
+    use core::panic;
+
     use super::{IncrementIntegerProvider, DEFAULT_START, DEFAULT_STEP};
     use crate::providers::provider::{Provider, Value};
 
     use yaml_rust::YamlLoader;
 
-    fn generate_provider(start: Option<&str>, step: Option<&str>) -> IncrementIntegerProvider {
+    fn generate_provider(start: Option<&str>, step: Option<&str>) -> Box<IncrementIntegerProvider> {
         let yaml_start = match start {
             Some(value) => format!("{}start: {}", "\n", value),
             None => String::new(),
@@ -47,13 +55,13 @@ mod tests {
         let yaml_str = format!("name: id{}{}", yaml_start, yaml_step);
 
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        IncrementIntegerProvider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     // Parquet type
     #[test]
     fn given_nothing_should_return_parquet_type() {
-        let provider: IncrementIntegerProvider = generate_provider(None, None);
+        let provider = generate_provider(None, None);
         match provider.value(0) {
             Value::Int32(_) => (),
             _ => panic!(),
@@ -141,6 +149,31 @@ mod tests {
                     let calculated = provider.value(value);
                     assert_eq!(calculated, Value::Int32(start + (value as i32 * step)));
                 }
+            }
+        }
+    }
+
+    // Corrupted value
+    #[test]
+    fn given_increment_integer_provider_should_corrupted_return_random_int() {
+        let start_to_check = [-14, 12, 17, 23];
+        let step_to_check = [-4, -1, 0, 1, 2, 3, 5];
+        let values_to_check = [0, 4, 50];
+
+        for start in start_to_check {
+            for step in step_to_check {
+                let provider = IncrementIntegerProvider { start, step };
+
+                let mut is_random_int = false;
+                for value in values_to_check {
+                    let calculated = match provider.corrupted_value(value) {
+                        Value::Int32(res) => res,
+                        _ => panic!("Should not happen"),
+                    };
+                    is_random_int =
+                        calculated < start || calculated >= (start + value as i32 * step);
+                }
+                assert!(is_random_int)
             }
         }
     }

--- a/src/providers/person/builder.rs
+++ b/src/providers/person/builder.rs
@@ -1,9 +1,9 @@
 use crate::errors::FakeLakeError;
 use crate::providers::provider::Provider;
 
-use super::email::EmailProvider;
-use super::fname::FirstNameProvider;
-use super::lname::LastNameProvider;
+use super::email;
+use super::fname;
+use super::lname;
 
 use yaml_rust::Yaml;
 
@@ -12,9 +12,9 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("email") => Ok(Box::new(EmailProvider::new_from_yaml(column))),
-        Some("fname") => Ok(Box::new(FirstNameProvider::new_from_yaml(column))),
-        Some("lname") => Ok(Box::new(LastNameProvider::new_from_yaml(column))),
+        Some("email") => Ok(email::new_from_yaml(column)),
+        Some("fname") => Ok(fname::new_from_yaml(column)),
+        Some("lname") => Ok(lname::new_from_yaml(column)),
         _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
     }
 }

--- a/src/providers/person/fname.rs
+++ b/src/providers/person/fname.rs
@@ -1,4 +1,7 @@
-use crate::providers::provider::{Provider, Value};
+use crate::providers::{
+    provider::{Provider, Value},
+    utils::string::random_characters,
+};
 
 use once_cell::sync::Lazy;
 use yaml_rust::Yaml;
@@ -16,9 +19,13 @@ impl Provider for FirstNameProvider {
         let index = fastrand::usize(..FIRST_NAMES.len());
         Value::String(FIRST_NAMES[index].to_string())
     }
-    fn new_from_yaml(_: &Yaml) -> FirstNameProvider {
-        FirstNameProvider {}
+    fn corrupted_value(&self, _: u32) -> Value {
+        Value::String(random_characters(10))
     }
+}
+
+pub fn new_from_yaml(_: &Yaml) -> Box<FirstNameProvider> {
+    Box::new(FirstNameProvider {})
 }
 
 #[cfg(test)]
@@ -28,16 +35,16 @@ mod tests {
 
     use yaml_rust::YamlLoader;
 
-    fn generate_provider() -> FirstNameProvider {
+    fn generate_provider() -> Box<FirstNameProvider> {
         let yaml_str = "name: id".to_string();
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        FirstNameProvider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     // Parquet type
     #[test]
     fn given_nothing_should_return_parquet_type() {
-        let provider: FirstNameProvider = generate_provider();
+        let provider = generate_provider();
         match provider.value(0) {
             Value::String(_) => (),
             _ => panic!(),
@@ -47,9 +54,18 @@ mod tests {
     // Validate value calculation
     #[test]
     fn given_nothing_should_return_name_from_list() {
-        let provider: FirstNameProvider = generate_provider();
+        let provider = generate_provider();
         match provider.value(0) {
             Value::String(value) => assert!(FIRST_NAMES.contains(&value.as_str())),
+            _ => panic!("Wrong type"),
+        }
+    }
+
+    #[test]
+    fn given_nothing_should_corrupted_return_name_not_from_list() {
+        let provider = generate_provider();
+        match provider.corrupted_value(0) {
+            Value::String(value) => assert!(!FIRST_NAMES.contains(&value.as_str())),
             _ => panic!("Wrong type"),
         }
     }

--- a/src/providers/person/lname.rs
+++ b/src/providers/person/lname.rs
@@ -1,4 +1,7 @@
-use crate::providers::provider::{Provider, Value};
+use crate::providers::{
+    provider::{Provider, Value},
+    utils::string::random_characters,
+};
 
 use once_cell::sync::Lazy;
 use yaml_rust::Yaml;
@@ -16,9 +19,13 @@ impl Provider for LastNameProvider {
         let index = fastrand::usize(..LAST_NAMES.len());
         Value::String(LAST_NAMES[index].to_string())
     }
-    fn new_from_yaml(_: &Yaml) -> LastNameProvider {
-        LastNameProvider {}
+    fn corrupted_value(&self, _: u32) -> Value {
+        Value::String(random_characters(10))
     }
+}
+
+pub fn new_from_yaml(_: &Yaml) -> Box<LastNameProvider> {
+    Box::new(LastNameProvider {})
 }
 
 #[cfg(test)]
@@ -28,16 +35,16 @@ mod tests {
 
     use yaml_rust::YamlLoader;
 
-    fn generate_provider() -> LastNameProvider {
+    fn generate_provider() -> Box<LastNameProvider> {
         let yaml_str = "name: id".to_string();
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        LastNameProvider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     // Parquet type
     #[test]
     fn given_nothing_should_return_parquet_type() {
-        let provider: LastNameProvider = generate_provider();
+        let provider = generate_provider();
         match provider.value(0) {
             Value::String(_) => (),
             _ => panic!(),
@@ -47,9 +54,18 @@ mod tests {
     // Validate value calculation
     #[test]
     fn given_nothing_should_return_name_from_list() {
-        let provider: LastNameProvider = generate_provider();
+        let provider = generate_provider();
         match provider.value(0) {
             Value::String(value) => assert!(LAST_NAMES.contains(&value.as_str())),
+            _ => panic!("Wrong type"),
+        }
+    }
+
+    #[test]
+    fn given_nothing_should_corrupted_return_name_not_from_list() {
+        let provider = generate_provider();
+        match provider.corrupted_value(0) {
+            Value::String(value) => assert!(!LAST_NAMES.contains(&value.as_str())),
             _ => panic!("Wrong type"),
         }
     }

--- a/src/providers/provider.rs
+++ b/src/providers/provider.rs
@@ -1,11 +1,12 @@
 use crate::errors::FakeLakeError;
 use crate::providers;
+use crate::providers::parameters::percentage::PercentageParameter;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use core::fmt;
 use yaml_rust::Yaml;
 
-#[derive(PartialEq, fmt::Debug)]
+#[derive(Clone, PartialEq, fmt::Debug)]
 pub enum Value {
     Bool(bool),
     Int32(i32),
@@ -30,9 +31,48 @@ where
 
 pub trait Provider: CloneProvider + Send + Sync {
     fn value(&self, index: u32) -> Value;
-    fn new_from_yaml(column: &Yaml) -> Self
-    where
-        Self: Sized;
+    fn corrupted_value(&self, index: u32) -> Value;
+}
+
+pub struct CorruptedProvider {
+    pub provider: Box<dyn Provider>,
+    pub corrupted: f64,
+}
+
+impl Clone for CorruptedProvider {
+    fn clone(&self) -> Self {
+        CorruptedProvider {
+            provider: self.provider.clone_box(),
+            corrupted: self.corrupted,
+        }
+    }
+}
+
+impl Provider for CorruptedProvider {
+    fn value(&self, index: u32) -> Value {
+        let rnd: f64 = fastrand::f64();
+        match rnd < self.corrupted {
+            true => self.corrupted_value(index),
+            false => self.provider.value(index),
+        }
+    }
+    fn corrupted_value(&self, index: u32) -> Value {
+        self.provider.corrupted_value(index)
+    }
+}
+
+impl CorruptedProvider {
+    pub fn new_from_yaml(column: &Yaml, provider: Box<dyn Provider>) -> Box<dyn Provider> {
+        let corrupted = PercentageParameter::new(column, "corrupted", 0 as f64).value;
+
+        match corrupted {
+            x if x == 0 as f64 => provider,
+            _ => Box::new(CorruptedProvider {
+                provider,
+                corrupted,
+            }),
+        }
+    }
 }
 
 // Implement Debug for all types that implement Provider
@@ -74,14 +114,32 @@ pub fn unknown_provider(wrong_provider: &str) -> FakeLakeError {
 
 #[cfg(test)]
 mod tests {
-    use super::ProviderBuilder;
+    use super::{CorruptedProvider, Provider, ProviderBuilder, Value};
 
     use yaml_rust::YamlLoader;
+
+    use mockall::predicate::*;
+    use mockall::*;
+
+    #[derive(Clone)]
+    struct TestProvider;
+    mock! {
+        pub TestProvider {}
+
+        impl Clone for TestProvider {
+            fn clone(&self) -> Self;
+        }
+
+        impl Provider for TestProvider {
+            fn value(&self, index: u32) -> Value;
+            fn corrupted_value(&self, index: u32) -> Value;
+        }
+    }
 
     #[test]
     fn given_increment_should_return_provider() {
         let provider_name = "increment.integer";
-        let yaml_str = format!("name: name{}provider: {}", '\n', provider_name);
+        let yaml_str = format!("name: test_col{}provider: {}", '\n', provider_name);
         let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
 
         match ProviderBuilder::get_corresponding_provider(provider_name, column) {
@@ -93,7 +151,7 @@ mod tests {
     #[test]
     fn given_person_should_return_provider() {
         let provider_name = "person.email";
-        let yaml_str = format!("name: name{}provider: {}", '\n', provider_name);
+        let yaml_str = format!("name: test_col{}provider: {}", '\n', provider_name);
         let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
 
         match ProviderBuilder::get_corresponding_provider(provider_name, column) {
@@ -105,7 +163,7 @@ mod tests {
     #[test]
     fn given_random_should_return_provider() {
         let provider_name = "random.string.alphanumeric";
-        let yaml_str = format!("name: name{}provider: {}", '\n', provider_name);
+        let yaml_str = format!("name: test_col{}provider: {}", '\n', provider_name);
         let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
 
         match ProviderBuilder::get_corresponding_provider(provider_name, column) {
@@ -117,12 +175,131 @@ mod tests {
     #[test]
     fn given_wrong_provider_should_return_error() {
         let provider_name = "not_a_provider";
-        let yaml_str = format!("name: name{}provider: {}", '\n', provider_name);
+        let yaml_str = format!("name: test_col{}provider: {}", '\n', provider_name);
         let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
 
         match ProviderBuilder::get_corresponding_provider(provider_name, column) {
             Err(_) => (),
             _ => panic!(),
+        }
+    }
+
+    // Corrupted tests
+    #[test]
+    fn given_corrupted_provider_corrupted_should_clone_be_identical() {
+        let mut mock_provider = MockTestProvider::new();
+        let mut mock_cloned = MockTestProvider::new();
+
+        mock_provider
+            .expect_value()
+            .return_const(Value::String("This is a unique string".to_string()));
+        mock_cloned
+            .expect_value()
+            .return_const(Value::String("This is a unique string".to_string()));
+
+        mock_provider
+            .expect_corrupted_value()
+            .return_const(Value::String("This is a second unique string".to_string()));
+        mock_cloned
+            .expect_corrupted_value()
+            .return_const(Value::String("This is a second unique string".to_string()));
+
+        mock_provider
+            .expect_clone()
+            .return_once(move || mock_cloned);
+
+        let corrupted = CorruptedProvider {
+            provider: Box::new(mock_provider),
+            corrupted: 1.0,
+        };
+        let cloned_corrupted = corrupted.clone();
+
+        let l = [1, 10, 100, 200];
+        for i in l {
+            assert_eq!(corrupted.value(i), cloned_corrupted.corrupted_value(i));
+            assert_eq!(cloned_corrupted.value(i), corrupted.corrupted_value(i));
+        }
+    }
+
+    #[test]
+    fn given_no_corrupted_should_not_call_corrupt() {
+        let yaml_str = "name: test_col".to_string();
+        let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
+
+        let mut mock_provider = Box::new(MockTestProvider::new());
+        mock_provider.expect_corrupted_value().never();
+
+        mock_provider
+            .expect_value()
+            .times(100)
+            .return_const(Value::String(String::new()));
+
+        let corr = CorruptedProvider::new_from_yaml(column, mock_provider);
+        for i in 0..100 {
+            corr.value(i);
+        }
+    }
+
+    #[test]
+    fn given_0_corrupted_should_not_call_corrupt() {
+        let corrupted_value = "0";
+        let yaml_str = format!("name: test_col{}corrupted: {}", "\n", corrupted_value);
+        let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
+
+        let mut mock_provider = Box::new(MockTestProvider::new());
+        mock_provider.expect_corrupted_value().never();
+
+        mock_provider
+            .expect_value()
+            .times(100)
+            .return_const(Value::String(String::new()));
+
+        let corr = CorruptedProvider::new_from_yaml(column, mock_provider);
+        for i in 0..100 {
+            corr.value(i);
+        }
+    }
+
+    #[test]
+    fn given_1_corrupted_should_only_call_corrupt() {
+        let corrupted_value = "1";
+        let yaml_str = format!("name: test_col{}corrupted: {}", "\n", corrupted_value);
+        let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
+
+        let mut mock_provider = Box::new(MockTestProvider::new());
+        mock_provider.expect_value().never();
+
+        mock_provider
+            .expect_corrupted_value()
+            .times(100)
+            .return_const(Value::String(String::new()));
+
+        let corr = CorruptedProvider::new_from_yaml(column, mock_provider);
+        for i in 0..100 {
+            corr.value(i);
+        }
+    }
+
+    #[test]
+    fn given_0_5_corrupted_should_call_corrupt() {
+        let corrupted_value = "0.5";
+        let yaml_str = format!("name: test_col{}corrupted: {}", "\n", corrupted_value);
+        let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
+
+        let mut mock_provider = Box::new(MockTestProvider::new());
+        mock_provider
+            .expect_corrupted_value()
+            .times(450..550)
+            .return_const(Value::String(String::new()));
+
+        mock_provider
+            .expect_value()
+            .times(450..550)
+            .return_const(Value::String(String::new()));
+
+        let corr = CorruptedProvider::new_from_yaml(column, mock_provider);
+        for i in 0..1000 {
+            corr.value(i);
         }
     }
 }

--- a/src/providers/random/bool.rs
+++ b/src/providers/random/bool.rs
@@ -9,9 +9,14 @@ impl Provider for BoolProvider {
     fn value(&self, _: u32) -> Value {
         Value::Bool(fastrand::bool())
     }
-    fn new_from_yaml(_: &Yaml) -> BoolProvider {
-        BoolProvider {}
+    fn corrupted_value(&self, index: u32) -> Value {
+        // Corrupted boolean is not valid
+        self.value(index)
     }
+}
+
+pub fn new_from_yaml(_: &Yaml) -> Box<BoolProvider> {
+    Box::new(BoolProvider {})
 }
 
 #[cfg(test)]
@@ -21,11 +26,11 @@ mod tests {
 
     use yaml_rust::YamlLoader;
 
-    fn generate_provider() -> BoolProvider {
+    fn generate_provider() -> Box<BoolProvider> {
         let yaml_str = "name: is_present".to_string();
 
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        BoolProvider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     // Validate YAML file
@@ -42,5 +47,16 @@ mod tests {
     #[test]
     fn given_no_config_should_return_default() {
         let _ = generate_provider();
+    }
+
+    #[test]
+    fn given_provider_should_corrupted_return_default() {
+        let provider = generate_provider();
+        for i in 0..100 {
+            match provider.corrupted_value(i) {
+                Value::Bool(_) => continue,
+                _ => panic!("Should not happen"),
+            };
+        }
     }
 }

--- a/src/providers/random/builder.rs
+++ b/src/providers/random/builder.rs
@@ -10,7 +10,7 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("bool") => Ok(Box::new(bool::BoolProvider::new_from_yaml(column))),
+        Some("bool") => Ok(bool::new_from_yaml(column)),
         Some("date") => date::builder::get_corresponding_provider(provider_split, column),
         Some("number") => number::builder::get_corresponding_provider(provider_split, column),
         Some("string") => string::builder::get_corresponding_provider(provider_split, column),

--- a/src/providers/random/date/builder.rs
+++ b/src/providers/random/date/builder.rs
@@ -1,8 +1,8 @@
 use crate::errors::FakeLakeError;
 use crate::providers::provider::Provider;
 
-use super::date::DateProvider;
-use super::datetime::DatetimeProvider;
+use super::date;
+use super::datetime;
 
 use yaml_rust::Yaml;
 
@@ -11,8 +11,8 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("date") => Ok(Box::new(DateProvider::new_from_yaml(column))),
-        Some("datetime") => Ok(Box::new(DatetimeProvider::new_from_yaml(column))),
+        Some("date") => Ok(date::new_from_yaml(column)),
+        Some("datetime") => Ok(datetime::new_from_yaml(column)),
         _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
     }
 }

--- a/src/providers/random/date/date.rs
+++ b/src/providers/random/date/date.rs
@@ -1,12 +1,15 @@
 use crate::providers::parameters::date::DateParameter;
 use crate::providers::provider::{Provider, Value};
 
-use chrono::NaiveDate;
+use chrono::{Datelike, NaiveDate};
 use yaml_rust::Yaml;
 
 const DEFAULT_FORMAT: &str = "%Y-%m-%d";
 const DEFAULT_AFTER: &str = "1980-01-01";
 const DEFAULT_BEFORE: &str = "2000-01-01";
+
+const MIN_DATE: NaiveDate = NaiveDate::MIN;
+const MAX_DATE: NaiveDate = NaiveDate::MAX;
 
 #[derive(Clone)]
 pub struct DateProvider {
@@ -22,15 +25,25 @@ impl Provider for DateProvider {
             self.format.clone(),
         )
     }
-    fn new_from_yaml(column: &Yaml) -> DateProvider {
-        let parameter = DateParameter::new(column, DEFAULT_FORMAT, DEFAULT_AFTER, DEFAULT_BEFORE);
-
-        DateProvider {
-            format: parameter.format,
-            after: parameter.after,
-            before: parameter.before,
-        }
+    fn corrupted_value(&self, _: u32) -> Value {
+        Value::Date(
+            NaiveDate::from_num_days_from_ce_opt(fastrand::i32(
+                MIN_DATE.num_days_from_ce()..MAX_DATE.num_days_from_ce(),
+            ))
+            .unwrap(),
+            self.format.clone(),
+        )
     }
+}
+
+pub fn new_from_yaml(column: &Yaml) -> Box<DateProvider> {
+    let parameter = DateParameter::new(column, DEFAULT_FORMAT, DEFAULT_AFTER, DEFAULT_BEFORE);
+
+    Box::new(DateProvider {
+        format: parameter.format,
+        after: parameter.after,
+        before: parameter.before,
+    })
 }
 
 #[cfg(test)]
@@ -45,7 +58,7 @@ mod tests {
         format: Option<&str>,
         after: Option<&str>,
         before: Option<&str>,
-    ) -> DateProvider {
+    ) -> Box<DateProvider> {
         let yaml_format = match format {
             Some(value) => format!("{}format: \"{}\"", "\n", value),
             None => String::new(),
@@ -62,7 +75,7 @@ mod tests {
         let yaml_str = format!("name: id{}{}{}", yaml_format, yaml_after, yaml_before);
 
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        DateProvider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     fn get_day_since_year0(date: &str, format: &str) -> i32 {
@@ -75,7 +88,7 @@ mod tests {
     // Parquet type
     #[test]
     fn given_nothing_should_return_parquet_type() {
-        let provider: DateProvider = generate_provider(None, None, None);
+        let provider = generate_provider(None, None, None);
         match provider.value(0) {
             Value::Date(_, _) => (),
             _ => panic!(),
@@ -85,7 +98,7 @@ mod tests {
     // Validate YAML file
     #[test]
     fn given_no_params_should_give_default() {
-        let provider: DateProvider = generate_provider(None, None, None);
+        let provider = generate_provider(None, None, None);
 
         assert_eq!(provider.format, DEFAULT_FORMAT);
         assert_eq!(
@@ -149,5 +162,29 @@ mod tests {
                 _ => panic!("Wrong type"),
             }
         }
+    }
+
+    #[test]
+    fn given_provider_should_corrupted_return_random_date() {
+        let provider = DateProvider {
+            format: DEFAULT_FORMAT.to_string(),
+            after: get_day_since_year0(DEFAULT_AFTER, DEFAULT_FORMAT),
+            before: get_day_since_year0(DEFAULT_BEFORE, DEFAULT_FORMAT),
+        };
+
+        let mut count_random_date = 0;
+        for value in 1..100 {
+            match provider.corrupted_value(value) {
+                Value::Date(value, _) => {
+                    if value.num_days_from_ce() < provider.after
+                        || value.num_days_from_ce() > provider.before
+                    {
+                        count_random_date += 1
+                    }
+                }
+                _ => panic!("Wrong type"),
+            }
+        }
+        assert!(count_random_date >= 99)
     }
 }

--- a/src/providers/random/number/builder.rs
+++ b/src/providers/random/number/builder.rs
@@ -1,8 +1,7 @@
 use crate::errors::FakeLakeError;
 use crate::providers::provider::Provider;
 
-use super::f64::F64Provider;
-use super::i32::I32Provider;
+use super::{f64, i32};
 
 use yaml_rust::Yaml;
 
@@ -11,8 +10,8 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("i32") => Ok(Box::new(I32Provider::new_from_yaml(column))),
-        Some("f64") => Ok(Box::new(F64Provider::new_from_yaml(column))),
+        Some("f64") => Ok(f64::new_from_yaml(column)),
+        Some("i32") => Ok(i32::new_from_yaml(column)),
         _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
     }
 }

--- a/src/providers/random/number/f64.rs
+++ b/src/providers/random/number/f64.rs
@@ -18,27 +18,31 @@ impl Provider for F64Provider {
     fn value(&self, _: u32) -> Value {
         Value::Float64(fastrand_contrib::f64_range(self.min..self.max))
     }
-    fn new_from_yaml(column: &Yaml) -> F64Provider {
-        let yaml_min = F64Parameter::new(column, "min", DEFAULT_MIN).value;
-        let yaml_max = F64Parameter::new(column, "max", DEFAULT_MAX).value;
+    fn corrupted_value(&self, _: u32) -> Value {
+        Value::Float64(fastrand_contrib::f64_range(f64::MIN..f64::MAX))
+    }
+}
 
-        if yaml_min >= yaml_max {
-            warn!(
-                "Column {} min is not less or equal to max option. Default are used ([{} and {}[)",
-                get_column_name(column),
-                DEFAULT_MIN,
-                DEFAULT_MAX
-            );
-            F64Provider {
-                min: DEFAULT_MIN,
-                max: DEFAULT_MAX,
-            }
-        } else {
-            F64Provider {
-                min: yaml_min,
-                max: yaml_max,
-            }
-        }
+pub fn new_from_yaml(column: &Yaml) -> Box<F64Provider> {
+    let yaml_min = F64Parameter::new(column, "min", DEFAULT_MIN).value;
+    let yaml_max = F64Parameter::new(column, "max", DEFAULT_MAX).value;
+
+    if yaml_min >= yaml_max {
+        warn!(
+            "Column {} min is not less or equal to max option. Default are used ([{} and {}[)",
+            get_column_name(column),
+            DEFAULT_MIN,
+            DEFAULT_MAX
+        );
+        Box::new(F64Provider {
+            min: DEFAULT_MIN,
+            max: DEFAULT_MAX,
+        })
+    } else {
+        Box::new(F64Provider {
+            min: yaml_min,
+            max: yaml_max,
+        })
     }
 }
 
@@ -49,7 +53,7 @@ mod tests {
 
     use yaml_rust::YamlLoader;
 
-    fn generate_provider(min: Option<&str>, max: Option<&str>) -> F64Provider {
+    fn generate_provider(min: Option<&str>, max: Option<&str>) -> Box<F64Provider> {
         let yaml_min = match min {
             Some(value) => format!("{}min: {}", "\n", value),
             None => String::new(),
@@ -62,13 +66,13 @@ mod tests {
         let yaml_str = format!("name: id{}{}", yaml_min, yaml_max);
 
         let yaml = YamlLoader::load_from_str(yaml_str.as_str()).unwrap();
-        F64Provider::new_from_yaml(&yaml[0])
+        super::new_from_yaml(&yaml[0])
     }
 
     // Parquet type
     #[test]
     fn given_nothing_should_return_parquet_type() {
-        let provider: F64Provider = generate_provider(None, None);
+        let provider = generate_provider(None, None);
         match provider.value(0) {
             Value::Float64(_) => (),
             _ => panic!(),
@@ -78,7 +82,7 @@ mod tests {
     // Validate yaml config
     #[test]
     fn given_no_params_should_use_default() {
-        let provider: F64Provider = generate_provider(None, None);
+        let provider = generate_provider(None, None);
 
         assert_eq!(provider.min, DEFAULT_MIN);
         assert_eq!(provider.max, DEFAULT_MAX);
@@ -86,7 +90,7 @@ mod tests {
 
     #[test]
     fn given_normal_params_should_use_params() {
-        let provider: F64Provider = generate_provider(Some("-10.3"), Some("10.5"));
+        let provider = generate_provider(Some("-10.3"), Some("10.5"));
 
         assert_eq!(provider.min, -10.3);
         assert_eq!(provider.max, 10.5);
@@ -94,7 +98,7 @@ mod tests {
 
     #[test]
     fn given_no_max_param_should_use_default() {
-        let provider: F64Provider = generate_provider(Some("-40.6"), None);
+        let provider = generate_provider(Some("-40.6"), None);
 
         assert_eq!(provider.min, -40.6);
         assert_eq!(provider.max, DEFAULT_MAX);
@@ -102,7 +106,7 @@ mod tests {
 
     #[test]
     fn given_no_min_param_should_use_default() {
-        let provider: F64Provider = generate_provider(None, Some("40.3"));
+        let provider = generate_provider(None, Some("40.3"));
 
         assert_eq!(provider.min, DEFAULT_MIN);
         assert_eq!(provider.max, 40.3);
@@ -110,9 +114,28 @@ mod tests {
 
     #[test]
     fn given_inverted_min_max_params_should_use_default() {
-        let provider: F64Provider = generate_provider(Some("14.6"), Some("-24.5"));
+        let provider = generate_provider(Some("14.6"), Some("-24.5"));
 
         assert_eq!(provider.min, DEFAULT_MIN);
         assert_eq!(provider.max, DEFAULT_MAX);
+    }
+
+    #[test]
+    fn given_small_interval_should_corrupted_return_random() {
+        let provider = generate_provider(Some("-10.5"), Some("14.7"));
+
+        let mut count_random_float = 0;
+        for i in 0..100 {
+            let value = match provider.corrupted_value(i) {
+                Value::Float64(res) => res,
+                _ => panic!("Should not happen"),
+            };
+
+            if !(-10.5..=14.7).contains(&value) {
+                count_random_float += 1;
+            }
+        }
+
+        assert!(count_random_float >= 99);
     }
 }

--- a/src/providers/random/string/builder.rs
+++ b/src/providers/random/string/builder.rs
@@ -1,7 +1,7 @@
 use crate::errors::FakeLakeError;
 use crate::providers::provider::Provider;
 
-use super::alphanumeric::AlphanumericProvider;
+use super::alphanumeric;
 
 use yaml_rust::Yaml;
 
@@ -10,7 +10,7 @@ pub fn get_corresponding_provider(
     column: &Yaml,
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
-        Some("alphanumeric") => Ok(Box::new(AlphanumericProvider::new_from_yaml(column))),
+        Some("alphanumeric") => Ok(alphanumeric::new_from_yaml(column)),
         _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
     }
 }

--- a/src/providers/utils/string.rs
+++ b/src/providers/utils/string.rs
@@ -1,14 +1,31 @@
 use std::iter::repeat_with;
 
-pub fn random_characters(n: u32) -> String {
+pub fn random_alphanumeric(n: u32) -> String {
     repeat_with(fastrand::alphanumeric)
         .take(n as usize)
         .collect()
 }
 
+const EXCLUDE_CHAR_RANGE: u32 = 0xE000 - 0xD800;
+const MAX_CHAR: u32 = 0x10FFFF - EXCLUDE_CHAR_RANGE;
+
+pub fn random_characters(n: u32) -> String {
+    repeat_with(|| {
+        let random_char = fastrand::u32(0..=MAX_CHAR);
+
+        let shifted_char = match random_char {
+            result if result >= 0xD800 => result + EXCLUDE_CHAR_RANGE,
+            _ => random_char,
+        };
+        std::char::from_u32(shifted_char).unwrap()
+    })
+    .take(n as usize)
+    .collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::random_characters;
+    use super::{random_alphanumeric, random_characters};
     use regex::Regex;
 
     fn validate_string(calculated_value: String, length: u32) {
@@ -18,17 +35,31 @@ mod tests {
     }
 
     #[test]
-    fn given_0_should_receive_empty_string() {
+    fn given_0_random_alphanumeric_should_receive_empty_string() {
+        assert_eq!(random_alphanumeric(0), "");
+    }
+
+    #[test]
+    fn given_0_random_characters_should_receive_empty_string() {
         assert_eq!(random_characters(0), "");
     }
 
     // Validate random calculation
     #[test]
-    fn given_x_should_have_string_of_length_x() {
+    fn given_x_random_alphanumeric_should_have_string_of_length_x() {
+        let values_to_check = [4, 27, 50];
+        for length in values_to_check {
+            let generated_string = random_alphanumeric(length);
+            validate_string(generated_string, length);
+        }
+    }
+
+    #[test]
+    fn given_x_random_characters_should_have_string_of_length_x() {
         let values_to_check = [4, 27, 50];
         for length in values_to_check {
             let generated_string = random_characters(length);
-            validate_string(generated_string, length);
+            assert_eq!(generated_string.chars().count(), length.try_into().unwrap());
         }
     }
 }

--- a/tests/csv_all_options.yaml
+++ b/tests/csv_all_options.yaml
@@ -2,37 +2,46 @@ columns:
   - name: id
     provider: Increment.integer
     start: 42
+    step: 2
     presence: 0.8
+    corrupted: 0.0001
 
   - name: first_name
     provider: Person.fname
+    corrupted: 0.0001
 
   - name: last_name
     provider: Person.lname
+    corrupted: 0.0001
 
   - name: company_email
     provider: Person.email
     domain: soma-smart.com
+    corrupted: 0.0001
 
   - name: created
     provider: Random.Date.date
     format: "%Y-%m-%d"
     after: 2000-02-15
     before: 2020-07-17
+    corrupted: 0.0001
 
   - name: connection
     provider: Random.Date.datetime
     format: "%Y-%m-%d %H:%M:%S"
     after: 2000-02-15 12:15:00
     before: 2020-07-17 23:11:57
+    corrupted: 0.0001
 
   - name: code
     provider: Random.String.alphanumeric
     length: 20
+    corrupted: 0.0001
 
   - name: code_between_5_and_15
     provider: Random.String.alphanumeric
     length: 5..15
+    corrupted: 0.0001
 
   - name: is_subscribed
     provider: Random.bool
@@ -41,6 +50,7 @@ columns:
     provider: Random.Number.i32
     min: -100
     max: 100
+    corrupted: 0.0001
 
   - name: percentage
     provider: Random.Number.f64

--- a/tests/parquet_all_options.yaml
+++ b/tests/parquet_all_options.yaml
@@ -4,44 +4,54 @@ columns:
     start: 42
     step: 2
     presence: 0.8
+    corrupted: 0.0001
 
   - name: first_name
     provider: Person.fname
+    corrupted: 0.0001
 
   - name: last_name
     provider: Person.lname
+    corrupted: 0.0001
 
   - name: company_email
     provider: Person.email
     domain: soma-smart.com
+    corrupted: 0.0001
 
   - name: created
     provider: Random.Date.date
     format: "%Y-%m-%d"
     after: 2000-02-15
     before: 2020-07-17
+    corrupted: 0.0001
 
   - name: connection
     provider: Random.Date.datetime
     format: "%Y-%m-%d %H:%M:%S"
     after: 2000-02-15 12:15:00
     before: 2020-07-17 23:11:57
+    corrupted: 0.0001
 
   - name: code
     provider: Random.String.alphanumeric
     length: 20
+    corrupted: 0.0001
 
   - name: code_between_5_and_15
     provider: Random.String.alphanumeric
     length: 5..15
+    corrupted: 0.0001
 
   - name: is_subscribed
     provider: Random.bool
+    corrupted: 0.0001
 
   - name: score
     provider: Random.Number.i32
     min: -100
     max: 100
+    corrupted: 0.0001
 
   - name: percentage
     provider: Random.Number.f64


### PR DESCRIPTION
#33 

Specifying corrupted as a parameter for any provider will change a percentage of the content with a different behavior. It is still keeping the same type for now (because of parquet, this needs to change in the future)

The behavior depends on the provider's type:
- For strings, generally it will be a random string not in UTF8 format
- For date, timestamp or int32, it will be a random date/timestamp/int32 between min and max
- For bool it doesn't change anything