### PR TITLE
Prepare v1.7.2: fix file naming, improve error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "fakelake"
-version = "1.7.0"
+version = "1.7.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fakelake"
-version = "1.7.0"
+version = "1.7.2"
 edition = "2021"
 rust-version = "1.90.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ impl Column {
             let provider: Box<dyn Provider> =
                 match ProviderBuilder::get_corresponding_provider(provider, column) {
                     Ok(value) => CorruptedProvider::new_from_yaml(column, value),
-                    Err(e) => return Err(FakeLakeError::BadYAMLFormat(e.to_string())),
+                    Err(e) => return Err(e),
                 };
 
             let column = Column {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,10 @@ use std::io;
 #[derive(Debug)]
 pub enum FakeLakeError {
     BadYAMLFormat(String),
+    UnknownProvider {
+        provider: String,
+        available: &'static [&'static str],
+    },
     IOError(io::Error),
     CSVError(csv::Error),
     JSONError(serde_json::Error),
@@ -16,6 +20,17 @@ impl fmt::Display for FakeLakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             FakeLakeError::BadYAMLFormat(msg) => write!(f, "{}", msg),
+            FakeLakeError::UnknownProvider {
+                provider,
+                available,
+            } => {
+                write!(
+                    f,
+                    "Unknown provider: {}. Expected one of: {}",
+                    provider,
+                    available.join(", ")
+                )
+            }
             FakeLakeError::IOError(err) => write!(f, "IO error: {}", err),
             FakeLakeError::CSVError(err) => write!(f, "CSV error: {}", err),
             FakeLakeError::JSONError(err) => write!(f, "JSON error: {}", err),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,8 +14,14 @@ pub enum FakeLakeError {
 #[cfg(not(tarpaulin_include))]
 impl fmt::Display for FakeLakeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // For now, use the debug derived version
-        write!(f, "{:?}", self)
+        match self {
+            FakeLakeError::BadYAMLFormat(msg) => write!(f, "{}", msg),
+            FakeLakeError::IOError(err) => write!(f, "IO error: {}", err),
+            FakeLakeError::CSVError(err) => write!(f, "CSV error: {}", err),
+            FakeLakeError::JSONError(err) => write!(f, "JSON error: {}", err),
+            FakeLakeError::ParquetError(err) => write!(f, "Parquet error: {}", err),
+            FakeLakeError::ArrowError(err) => write!(f, "Arrow error: {}", err),
+        }
     }
 }
 

--- a/src/generate/output_format.rs
+++ b/src/generate/output_format.rs
@@ -30,11 +30,18 @@ pub trait OutputFormat {
             );
         }
 
+        let extension = self.get_extension();
+
         for f in 0..files {
             let file_name = if files == 1 {
                 default_file_name.clone()
             } else {
-                format!("{}_{}", default_file_name, f)
+                match default_file_name.rfind(extension) {
+                    Some(pos) if !extension.is_empty() => {
+                        format!("{}_{}{}", &default_file_name[..pos], f, extension)
+                    }
+                    _ => format!("{}_{}", default_file_name, f),
+                }
             };
 
             let file_seed = rng::derive_seed(root_seed, rng::DOMAIN_FILE, &[f as u64]);

--- a/src/generate/output_format.rs
+++ b/src/generate/output_format.rs
@@ -36,9 +36,9 @@ pub trait OutputFormat {
             let file_name = if files == 1 {
                 default_file_name.clone()
             } else {
-                match default_file_name.rfind(extension) {
-                    Some(pos) if !extension.is_empty() => {
-                        format!("{}_{}{}", &default_file_name[..pos], f, extension)
+                match default_file_name.strip_suffix(extension) {
+                    Some(stem) if !extension.is_empty() => {
+                        format!("{}_{}{}", stem, f, extension)
                     }
                     _ => format!("{}_{}", default_file_name, f),
                 }

--- a/src/providers/constant/builder.rs
+++ b/src/providers/constant/builder.rs
@@ -11,7 +11,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("string") => Ok(string::new_from_yaml(column)),
         Some("external") => Ok(external::new_from_yaml(column)),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: constant.{}. Expected one of: constant.string, constant.external",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/constant/builder.rs
+++ b/src/providers/constant/builder.rs
@@ -1,8 +1,11 @@
 use yaml_rust::Yaml;
 
-use crate::{errors::FakeLakeError, providers::provider::Provider};
+use crate::errors::FakeLakeError;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::{external, string};
+
+const AVAILABLE: &[&str] = &["constant.string", "constant.external"];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -11,10 +14,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("string") => Ok(string::new_from_yaml(column)),
         Some("external") => Ok(external::new_from_yaml(column)),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: constant.{}. Expected one of: constant.string, constant.external",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("constant.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/constant/builder.rs
+++ b/src/providers/constant/builder.rs
@@ -14,10 +14,7 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("string") => Ok(string::new_from_yaml(column)),
         Some("external") => Ok(external::new_from_yaml(column)),
-        other => Err(unknown_provider(
-            &format!("constant.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("constant", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/increment/builder.rs
+++ b/src/providers/increment/builder.rs
@@ -11,7 +11,10 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("integer") => Ok(integer::new_from_yaml(column)),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: increment.{}. Expected one of: increment.integer",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/increment/builder.rs
+++ b/src/providers/increment/builder.rs
@@ -1,9 +1,11 @@
 use crate::errors::FakeLakeError;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::integer;
 
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &["increment.integer"];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -11,10 +13,10 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("integer") => Ok(integer::new_from_yaml(column)),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: increment.{}. Expected one of: increment.integer",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("increment.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/increment/builder.rs
+++ b/src/providers/increment/builder.rs
@@ -13,10 +13,7 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("integer") => Ok(integer::new_from_yaml(column)),
-        other => Err(unknown_provider(
-            &format!("increment.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("increment", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/person/builder.rs
+++ b/src/providers/person/builder.rs
@@ -27,10 +27,7 @@ pub fn get_corresponding_provider(
         Some("email") => Ok(email::new_from_yaml(column)),
         Some("fname") => Ok(external::new(FIRST_NAMES.to_vec())),
         Some("lname") => Ok(external::new(LAST_NAMES.to_vec())),
-        other => Err(unknown_provider(
-            &format!("person.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("person", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/person/builder.rs
+++ b/src/providers/person/builder.rs
@@ -1,11 +1,13 @@
 use crate::errors::FakeLakeError;
 use crate::providers::constant::external;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::email;
 
 use once_cell::sync::Lazy;
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &["person.email", "person.fname", "person.lname"];
 
 static FIRST_NAMES: Lazy<Vec<String>> = Lazy::new(|| {
     let raw_first_names = include_str!("../../../static/first_name_fr.txt");
@@ -25,10 +27,10 @@ pub fn get_corresponding_provider(
         Some("email") => Ok(email::new_from_yaml(column)),
         Some("fname") => Ok(external::new(FIRST_NAMES.to_vec())),
         Some("lname") => Ok(external::new(LAST_NAMES.to_vec())),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: person.{}. Expected one of: person.email, person.fname, person.lname",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("person.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/person/builder.rs
+++ b/src/providers/person/builder.rs
@@ -25,7 +25,10 @@ pub fn get_corresponding_provider(
         Some("email") => Ok(email::new_from_yaml(column)),
         Some("fname") => Ok(external::new(FIRST_NAMES.to_vec())),
         Some("lname") => Ok(external::new(LAST_NAMES.to_vec())),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: person.{}. Expected one of: person.email, person.fname, person.lname",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/provider.rs
+++ b/src/providers/provider.rs
@@ -106,17 +106,28 @@ impl ProviderBuilder {
             Some("random") => {
                 providers::random::builder::get_corresponding_provider(provider_split, column)
             }
-            _ => Err(unknown_provider(
-                provider,
+            other => Err(unknown_provider(
+                "",
+                other,
                 &["constant.*", "increment.*", "person.*", "random.*"],
             )),
         }
     }
 }
 
-pub fn unknown_provider(wrong_provider: &str, available: &'static [&'static str]) -> FakeLakeError {
+pub fn unknown_provider(
+    prefix: &str,
+    segment: Option<&str>,
+    available: &'static [&'static str],
+) -> FakeLakeError {
+    let provider = match (prefix, segment) {
+        ("", Some(s)) => s.to_string(),
+        ("", None) => "<missing>".to_string(),
+        (p, Some(s)) => format!("{}.{}", p, s),
+        (p, None) => format!("{}.<missing>", p),
+    };
     FakeLakeError::UnknownProvider {
-        provider: wrong_provider.to_string(),
+        provider,
         available,
     }
 }

--- a/src/providers/provider.rs
+++ b/src/providers/provider.rs
@@ -106,13 +106,19 @@ impl ProviderBuilder {
             Some("random") => {
                 providers::random::builder::get_corresponding_provider(provider_split, column)
             }
-            _ => Err(unknown_provider(provider)),
+            _ => Err(unknown_provider(
+                provider,
+                &["constant.*", "increment.*", "person.*", "random.*"],
+            )),
         }
     }
 }
 
-pub fn unknown_provider(wrong_provider: &str) -> FakeLakeError {
-    FakeLakeError::BadYAMLFormat(format!("Unknown provider: {}", wrong_provider))
+pub fn unknown_provider(wrong_provider: &str, available: &'static [&'static str]) -> FakeLakeError {
+    FakeLakeError::UnknownProvider {
+        provider: wrong_provider.to_string(),
+        available,
+    }
 }
 
 #[cfg(test)]

--- a/src/providers/provider.rs
+++ b/src/providers/provider.rs
@@ -196,6 +196,33 @@ mod tests {
     }
 
     #[test]
+    fn given_valid_provider_case_insensitive_should_return_provider() {
+        let provider_names = [
+            "Constant.String",
+            "CONSTANT.STRING",
+            "Increment.Integer",
+            "INCREMENT.INTEGER",
+            "Person.Email",
+            "PERSON.EMAIL",
+            "Random.String.Alphanumeric",
+            "RANDOM.STRING.ALPHANUMERIC",
+            "Random.Number.I32",
+            "RANDOM.NUMBER.F64",
+            "Random.Date.Date",
+            "RANDOM.DATE.DATETIME",
+        ];
+        for provider_name in provider_names {
+            let yaml_str = format!("name: name{}provider: {}", '\n', provider_name);
+            let column = &YamlLoader::load_from_str(yaml_str.as_str()).unwrap()[0];
+
+            match ProviderBuilder::get_corresponding_provider(provider_name, column) {
+                Ok(_) => (),
+                _ => panic!("Provider '{}' should be resolved case-insensitively", provider_name),
+            }
+        }
+    }
+
+    #[test]
     fn given_wrong_provider_should_return_error() {
         let provider_name = "not_a_provider";
         let yaml_str = format!("name: test_col{}provider: {}", '\n', provider_name);

--- a/src/providers/provider.rs
+++ b/src/providers/provider.rs
@@ -217,7 +217,10 @@ mod tests {
 
             match ProviderBuilder::get_corresponding_provider(provider_name, column) {
                 Ok(_) => (),
-                _ => panic!("Provider '{}' should be resolved case-insensitively", provider_name),
+                _ => panic!(
+                    "Provider '{}' should be resolved case-insensitively",
+                    provider_name
+                ),
             }
         }
     }

--- a/src/providers/random/builder.rs
+++ b/src/providers/random/builder.rs
@@ -1,9 +1,16 @@
 use crate::errors::FakeLakeError;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::{bool, date, number, string};
 
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &[
+    "random.bool",
+    "random.date.*",
+    "random.number.*",
+    "random.string.*",
+];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -14,10 +21,10 @@ pub fn get_corresponding_provider(
         Some("date") => date::builder::get_corresponding_provider(provider_split, column),
         Some("number") => number::builder::get_corresponding_provider(provider_split, column),
         Some("string") => string::builder::get_corresponding_provider(provider_split, column),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: random.{}. Expected one of: random.bool, random.date.*, random.number.*, random.string.*",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("random.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/random/builder.rs
+++ b/src/providers/random/builder.rs
@@ -14,7 +14,10 @@ pub fn get_corresponding_provider(
         Some("date") => date::builder::get_corresponding_provider(provider_split, column),
         Some("number") => number::builder::get_corresponding_provider(provider_split, column),
         Some("string") => string::builder::get_corresponding_provider(provider_split, column),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: random.{}. Expected one of: random.bool, random.date.*, random.number.*, random.string.*",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/random/builder.rs
+++ b/src/providers/random/builder.rs
@@ -21,10 +21,7 @@ pub fn get_corresponding_provider(
         Some("date") => date::builder::get_corresponding_provider(provider_split, column),
         Some("number") => number::builder::get_corresponding_provider(provider_split, column),
         Some("string") => string::builder::get_corresponding_provider(provider_split, column),
-        other => Err(unknown_provider(
-            &format!("random.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("random", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/random/date/builder.rs
+++ b/src/providers/random/date/builder.rs
@@ -15,10 +15,7 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("date") => Ok(date::new_from_yaml(column)),
         Some("datetime") => Ok(datetime::new_from_yaml(column)),
-        other => Err(unknown_provider(
-            &format!("random.date.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("random.date", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/random/date/builder.rs
+++ b/src/providers/random/date/builder.rs
@@ -1,10 +1,12 @@
 use crate::errors::FakeLakeError;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::date;
 use super::datetime;
 
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &["random.date.date", "random.date.datetime"];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -13,10 +15,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("date") => Ok(date::new_from_yaml(column)),
         Some("datetime") => Ok(datetime::new_from_yaml(column)),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: random.date.{}. Expected one of: random.date.date, random.date.datetime",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("random.date.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/random/date/builder.rs
+++ b/src/providers/random/date/builder.rs
@@ -13,7 +13,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("date") => Ok(date::new_from_yaml(column)),
         Some("datetime") => Ok(datetime::new_from_yaml(column)),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: random.date.{}. Expected one of: random.date.date, random.date.datetime",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/random/number/builder.rs
+++ b/src/providers/random/number/builder.rs
@@ -1,9 +1,11 @@
 use crate::errors::FakeLakeError;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::{f64, i32};
 
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &["random.number.f64", "random.number.i32"];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -12,10 +14,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("f64") => Ok(f64::new_from_yaml(column)),
         Some("i32") => Ok(i32::new_from_yaml(column)),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: random.number.{}. Expected one of: random.number.f64, random.number.i32",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("random.number.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/random/number/builder.rs
+++ b/src/providers/random/number/builder.rs
@@ -14,10 +14,7 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("f64") => Ok(f64::new_from_yaml(column)),
         Some("i32") => Ok(i32::new_from_yaml(column)),
-        other => Err(unknown_provider(
-            &format!("random.number.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("random.number", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/random/number/builder.rs
+++ b/src/providers/random/number/builder.rs
@@ -12,7 +12,10 @@ pub fn get_corresponding_provider(
     match provider_split.next() {
         Some("f64") => Ok(f64::new_from_yaml(column)),
         Some("i32") => Ok(i32::new_from_yaml(column)),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: random.number.{}. Expected one of: random.number.f64, random.number.i32",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/src/providers/random/string/builder.rs
+++ b/src/providers/random/string/builder.rs
@@ -13,10 +13,7 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("alphanumeric") => Ok(alphanumeric::new_from_yaml(column)),
-        other => Err(unknown_provider(
-            &format!("random.string.{}", other.unwrap_or("<missing>")),
-            AVAILABLE,
-        )),
+        other => Err(unknown_provider("random.string", other, AVAILABLE)),
     }
 }
 

--- a/src/providers/random/string/builder.rs
+++ b/src/providers/random/string/builder.rs
@@ -1,9 +1,11 @@
 use crate::errors::FakeLakeError;
-use crate::providers::provider::Provider;
+use crate::providers::provider::{unknown_provider, Provider};
 
 use super::alphanumeric;
 
 use yaml_rust::Yaml;
+
+const AVAILABLE: &[&str] = &["random.string.alphanumeric"];
 
 pub fn get_corresponding_provider(
     mut provider_split: std::str::Split<'_, char>,
@@ -11,10 +13,10 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("alphanumeric") => Ok(alphanumeric::new_from_yaml(column)),
-        other => Err(FakeLakeError::BadYAMLFormat(format!(
-            "Unknown provider: random.string.{}. Expected one of: random.string.alphanumeric",
-            other.unwrap_or("<missing>")
-        ))),
+        other => Err(unknown_provider(
+            &format!("random.string.{}", other.unwrap_or("<missing>")),
+            AVAILABLE,
+        )),
     }
 }
 

--- a/src/providers/random/string/builder.rs
+++ b/src/providers/random/string/builder.rs
@@ -11,7 +11,10 @@ pub fn get_corresponding_provider(
 ) -> Result<Box<dyn Provider>, FakeLakeError> {
     match provider_split.next() {
         Some("alphanumeric") => Ok(alphanumeric::new_from_yaml(column)),
-        _ => Err(FakeLakeError::BadYAMLFormat("".to_string())),
+        other => Err(FakeLakeError::BadYAMLFormat(format!(
+            "Unknown provider: random.string.{}. Expected one of: random.string.alphanumeric",
+            other.unwrap_or("<missing>")
+        ))),
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -39,8 +39,8 @@ mod tests {
         fs::remove_file("target/parallel_threads.yaml").ok();
         fs::remove_file("target/multifile_seeded.yaml").ok();
         for i in 0..4 {
-            fs::remove_file(format!("target/multifile_seeded_run1.parquet_{i}")).ok();
-            fs::remove_file(format!("target/multifile_seeded_run2.parquet_{i}")).ok();
+            fs::remove_file(format!("target/multifile_seeded_run1_{i}.parquet")).ok();
+            fs::remove_file(format!("target/multifile_seeded_run2_{i}.parquet")).ok();
         }
     }
 
@@ -424,7 +424,7 @@ info:
             .assert()
             .success();
         let run1: Vec<Vec<u8>> = (0..4)
-            .map(|i| fs::read(format!("target/multifile_seeded_run1.parquet_{i}")))
+            .map(|i| fs::read(format!("target/multifile_seeded_run1_{i}.parquet")))
             .collect::<Result<_, _>>()?;
 
         // Run 2 — same config, write to a different prefix so we don't clobber run 1.
@@ -439,7 +439,7 @@ info:
             .assert()
             .success();
         let run2: Vec<Vec<u8>> = (0..4)
-            .map(|i| fs::read(format!("target/multifile_seeded_run2.parquet_{i}")))
+            .map(|i| fs::read(format!("target/multifile_seeded_run2_{i}.parquet")))
             .collect::<Result<_, _>>()?;
 
         // Each file_i is byte-identical across the two runs.
@@ -455,8 +455,8 @@ info:
         );
 
         for i in 0..4 {
-            fs::remove_file(format!("target/multifile_seeded_run1.parquet_{i}")).ok();
-            fs::remove_file(format!("target/multifile_seeded_run2.parquet_{i}")).ok();
+            fs::remove_file(format!("target/multifile_seeded_run1_{i}.parquet")).ok();
+            fs::remove_file(format!("target/multifile_seeded_run2_{i}.parquet")).ok();
         }
         fs::remove_file(config_path).ok();
         Ok(())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -42,6 +42,11 @@ mod tests {
             fs::remove_file(format!("target/multifile_seeded_run1_{i}.parquet")).ok();
             fs::remove_file(format!("target/multifile_seeded_run2_{i}.parquet")).ok();
         }
+        fs::remove_file("target/multifile_naming.yaml").ok();
+        for i in 0..3 {
+            fs::remove_file(format!("target/multifile_naming_{i}.csv")).ok();
+            fs::remove_file(format!("target/multifile_naming_{i}.json")).ok();
+        }
     }
 
     #[test]
@@ -458,6 +463,49 @@ info:
             fs::remove_file(format!("target/multifile_seeded_run1_{i}.parquet")).ok();
             fs::remove_file(format!("target/multifile_seeded_run2_{i}.parquet")).ok();
         }
+        fs::remove_file(config_path).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn given_multifile_csv_and_json_should_name_files_with_index_before_extension(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let config_path = Path::new("target/multifile_naming.yaml");
+
+        for format in &["csv", "json"] {
+            let config_content = format!(
+                r#"
+columns:
+  - name: id
+    provider: Increment.integer
+
+info:
+  output_name: target/multifile_naming
+  output_format: {}
+  rows: 3
+  files: 3
+  seed: 42
+"#,
+                format
+            );
+            fs::write(config_path, &config_content)?;
+            Command::cargo_bin("fakelake")?
+                .arg("generate")
+                .arg(config_path)
+                .assert()
+                .success();
+
+            for i in 0..3 {
+                let path = format!("target/multifile_naming_{i}.{format}");
+                assert!(Path::new(&path).exists(), "Expected file {} to exist", path);
+            }
+
+            // Clean up for next iteration
+            for i in 0..3 {
+                fs::remove_file(format!("target/multifile_naming_{i}.{format}")).ok();
+            }
+        }
+
         fs::remove_file(config_path).ok();
         Ok(())
     }


### PR DESCRIPTION
## Summary

- **Bump version** to 1.7.2 (was stuck at 1.7.0 in the v1.7.1 release)
- **Fix multi-file output naming**: files were named `output.csv_0` instead of `output_0.csv` when using `files: N`. The index suffix is now inserted before the extension for all formats (CSV, JSON, Parquet)
- **Confirm case-insensitive provider lookup**: provider names like `RANDOM.NUMBER.F64` or `Person.Fname` already resolve correctly — added explicit tests documenting this behavior
- **Improve unknown provider error messages**: sub-builders returned empty error strings that got double-wrapped into unreadable `BadYAMLFormat("BadYAMLFormat(\"\")")` messages. Now each builder reports the unrecognized segment and lists valid options (e.g. `Unknown provider: random.float. Expected one of: random.bool, random.date.*, random.number.*, random.string.*`). Also fixed `FakeLakeError::Display` to produce human-readable output instead of Debug formatting

## Test plan

- [x] All 302 unit tests pass
- [x] All 16 integration tests pass (including `given_seeded_multifile_parquet_should_be_reproducible` updated for new naming)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Manual verification: `files: 3` produces `output_0.csv`, `output_1.csv`, `output_2.csv`
- [x] Manual verification: invalid provider `random.float` now shows helpful error with suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)